### PR TITLE
docs: fix simple typo, sliceing -> slicing

### DIFF
--- a/Datatypes/README.md
+++ b/Datatypes/README.md
@@ -7,7 +7,7 @@
 所有序列类型都可以进行某些通用的操作，比如：
 
 - 索引（indexing）
-- 分片（sliceing）
+- 分片（slicing）
 - 迭代（iteration）
 - 加（adding）
 - 乘（multiplying）


### PR DESCRIPTION
There is a small typo in Datatypes/README.md.

Should read `slicing` rather than `sliceing`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md